### PR TITLE
Update Adafruit_BNO08x_RVC.cpp: Handle a full serial buffer and retrieve most recent data

### DIFF
--- a/Adafruit_BNO08x_RVC.cpp
+++ b/Adafruit_BNO08x_RVC.cpp
@@ -63,67 +63,90 @@ bool Adafruit_BNO08x_RVC::begin(Stream *theSerial) {
 }
 
 /**
- * @brief Get the next available heading and acceleration data from the sensor
+ * @brief Get the next available gyro and acceleration data from the sensor
  *
- * @param heading pointer to a BNO08x_RVC_Data struct to hold the measurements
+ * @param RVC_Data pointer to a BNO08x_RVC_Data struct to hold the measurements
  * @return true: success false: failure
  */
-bool Adafruit_BNO08x_RVC::read(BNO08x_RVC_Data *heading) {
-  if (!heading) {
+bool Adafruit_BNO08x_RVC::read(BNO08x_RVC_Data *RVC_Data) {
+  // Each BNO085 report is prefixed with a header 0xAAAA
+  byte headerByte = 0xAA; // Because the first and second bytes of the header are identical, we only define one byte to minimize processing time.
+  uint8_t buffer[17]; // Each data packet is 19 bytes long, 2 of which are the header. 
+
+  if (!RVC_Data) {
     return false;
   }
 
   if (!serial_dev->available()) {
+    Serial.println("No bytes available to read.");
     return false;
   }
-  if (serial_dev->peek() != 0xAA) {
-    serial_dev->read();
-    return false;
-  }
-  // Now read all 19 bytes
 
+  // Are there at least 19 bytes in the buffer?
   if (serial_dev->available() < 19) {
+    // Nope. 
     return false;
   }
-  // at this point we know there's at least 19 bytes available and the first
-  if (serial_dev->read() != 0xAA) {
-    // shouldn't happen baecause peek said it was 0xAA
-    return false;
+  else { 
+    // There's at least 19 bytes in the buffer.     
+    //int numOfGoodPackets = 0; // For grins, keep track of how many good packets we find in the buffer.
+    // Get the most recent data packet and discard any older data
+    while(serial_dev->available() >= 19) {
+      // Look for the first header byte
+      if(serial_dev->peek() == headerByte) {
+        serial_dev->read(); // Consume the first header byte
+
+        // Is the second byte of the header correct?
+        bool validHeader = true;
+        if(serial_dev->peek() != headerByte) {
+          validHeader = false;
+        }
+        else { 
+          serial_dev->read(); // Consume the header byte
+        }
+
+        // If the header is valid, read the rest of the packet
+        if(validHeader) {
+          for(int i = 0; i < 17; i++) {
+            buffer[i] = serial_dev->read();
+          }
+          //numOfGoodPackets++;
+        }
+      } 
+      else {
+        serial_dev->read(); // Discard the non-header byte
+      }
+    } // end while()
+    //Serial.println("Using the most recent data from the " + String(numOfGoodPackets) + " data packets that were in the buffer.");
+
+
+    // Validate and Process the Data *****************************/ 
+
+    // Checksum
+    uint8_t sum = 0;
+    for (uint8_t i = 0; i < 16; i++) {
+      sum += buffer[i];
+    }
+    if (sum != buffer[16]) {
+      return false;
+    }
+
+    // The data comes in endian'd, this solves it so it works on all platforms
+    int16_t buffer_16[6];
+
+    for (uint8_t i = 0; i < 6; i++) {
+
+      buffer_16[i] = (buffer[1 + (i * 2)]);
+      buffer_16[i] += (buffer[1 + (i * 2) + 1] << 8);
+    }
+    RVC_Data->yaw = (float)buffer_16[0] * DEGREE_SCALE;
+    RVC_Data->pitch = (float)buffer_16[1] * DEGREE_SCALE;
+    RVC_Data->roll = (float)buffer_16[2] * DEGREE_SCALE;
+
+    RVC_Data->x_accel = (float)buffer_16[3] * MILLI_G_TO_MS2;
+    RVC_Data->y_accel = (float)buffer_16[4] * MILLI_G_TO_MS2;
+    RVC_Data->z_accel = (float)buffer_16[5] * MILLI_G_TO_MS2;
+    return true;
   }
-  // make sure the next byte is the second 0xAA
-  if (serial_dev->read() != 0xAA) {
-    return false;
-  }
-  uint8_t buffer[19];
-  // ok, we've got our header, read the actual data+crc
-  if (!serial_dev->readBytes(buffer, 17)) {
-    return false;
-  };
-
-  uint8_t sum = 0;
-  // get checksum ready
-  for (uint8_t i = 0; i < 16; i++) {
-    sum += buffer[i];
-  }
-  if (sum != buffer[16]) {
-    return false;
-  }
-
-  // The data comes in endian'd, this solves it so it works on all platforms
-  int16_t buffer_16[6];
-
-  for (uint8_t i = 0; i < 6; i++) {
-
-    buffer_16[i] = (buffer[1 + (i * 2)]);
-    buffer_16[i] += (buffer[1 + (i * 2) + 1] << 8);
-  }
-  heading->yaw = (float)buffer_16[0] * DEGREE_SCALE;
-  heading->pitch = (float)buffer_16[1] * DEGREE_SCALE;
-  heading->roll = (float)buffer_16[2] * DEGREE_SCALE;
-
-  heading->x_accel = (float)buffer_16[3] * MILLI_G_TO_MS2;
-  heading->y_accel = (float)buffer_16[4] * MILLI_G_TO_MS2;
-  heading->z_accel = (float)buffer_16[5] * MILLI_G_TO_MS2;
-
-  return true;
 }
+


### PR DESCRIPTION
My tests show that the BNO085 spits out data every 11ms when using the Feather ESP32 V2. If not polling the BNO085 at that interval or faster, the serial buffer will accumulate data from the BNO085. 

If the user is polling every 100ms for example, there will be 9 data packets in the buffer. When the user polls the data, it will retrieve the oldest packet - 9 packets ago. It would take 9 successive reads before being caught up to the most recent data.

Even more importantly, because the buffer has had time to fill, it will have more than one packet of data. The current code only checks to see that there's at least 19 bytes in the buffer, but never checks to see if there's more than 19bytes.  This will cause successive read failures! 

The update proposed here handles anywere from 0 packets in the buffer to a full buffer. It will go through all the fully formed packets in the buffer, discarding all but the most recent data packet.

I've tested the updated code, sampling at 2ms and up to 1 second.

I modified the function:
bool Adafruit_BNO08x_RVC::read(BNO08x_RVC_Data *RVC_Data) {}

I also made some readability edits, such as changing "heading" to "RVC_Data", which made more sense to me. ("heading" to me suggested 0-359 degrees.)  I find it easier now to read through the function's code and understand what is going on. 